### PR TITLE
Add orchestrator: Kimi K2.5 driving Claude Code AIs hourly

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,47 @@ actions:
    docker-compose logs openclaw-normal
    ```
 
+## Orchestrator (Hourly Cron)
+
+The orchestrator is a Kimi K2.5-driven agent that runs every hour via `openclaw cron`. It dispatches tasks to Claude Code AIs.
+
+### What It Does
+
+| Task | Description |
+|------|-------------|
+| **PR Review & Merge** | Scans GitHub repos for open PRs, reviews diffs using Claude Code AI, approves/merges or requests changes |
+| **Update Checks** | Checks for new versions of openclaw, claude-code, kimi-code, and the launcher repo |
+| **Session Maintenance** | Runs `openclaw sessions cleanup --all-agents --enforce` and reindexes memory |
+| **Memory-Aware Review** | Uses `openclaw memory search` to provide context when reviewing PRs |
+
+### Quick Start
+
+```bash
+# Start everything (gateway + watcher + orchestrator cron)
+./launch.sh
+
+# Or install just the cron job (gateway must be running)
+./launch.sh --cron-only
+
+# Manual run
+bash orchestrator/orchestrator.sh
+
+# Check cron status
+openclaw cron list
+```
+
+### Architecture
+
+```
+openclaw cron (every 1h)
+  └─> Kimi K2.5 (kimi-coding/k2p5) — brain/orchestrator
+       └─> Claude Code AIs — executor
+            ├─> Review PR diffs
+            ├─> Run tests
+            ├─> Approve & merge
+            └─> Check for updates
+```
+
 ## Contributing
 
 1. Fork the repository

--- a/gateway-watcher.sh
+++ b/gateway-watcher.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# gateway-watcher.sh — Self-healing gateway monitor for OpenClawMaster
+# Runs as a background loop. Detects: 409 conflicts, crashes, unresponsive gateway.
+# Self-heals, then escalates to kimi -c for diagnosis if repeated failures.
+
+# Fix: OPENCLAW_HOME must not be set
+unset OPENCLAW_HOME
+
+CHECK_INTERVAL=${CHECK_INTERVAL:-120}
+LOG="/home/openclaw/logs/gateway-watcher.log"
+MAX_LOG_SIZE=5242880
+GATEWAY_PORT=18790
+CONSECUTIVE_FAILURES=0
+MAX_FAILURES_BEFORE_KIMI=3
+
+log() {
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "[$ts] $1" >> "$LOG"
+  echo "[$ts] [gateway-watcher] $1"
+}
+
+rotate_log() {
+  if [ -f "$LOG" ]; then
+    local size
+    size=$(stat -c%s "$LOG" 2>/dev/null || echo 0)
+    if [ "$size" -gt "$MAX_LOG_SIZE" ]; then
+      mv "$LOG" "$LOG.old"
+      log "Log rotated"
+    fi
+  fi
+}
+
+check_gateway_alive() {
+  pgrep -f "openclaw.*gateway" >/dev/null 2>&1
+}
+
+check_gateway_responsive() {
+  timeout 10 bash -c "echo > /dev/tcp/127.0.0.1/$GATEWAY_PORT" 2>/dev/null
+}
+
+restart_gateway() {
+  log "Restarting gateway..."
+  pkill -9 -f "openclaw.*gateway" 2>/dev/null || true
+  sleep 2
+
+  export PATH=/home/openclaw/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH
+  export HOME=/home/openclaw
+
+  if [ -f /home/openclaw/.env.keys ]; then
+    set -a
+    source /home/openclaw/.env.keys
+    set +a
+  fi
+
+  nohup openclaw gateway run --force --bind loopback --port $GATEWAY_PORT \
+    >> /home/openclaw/logs/gateway-restart.log 2>&1 &
+
+  sleep 5
+  if check_gateway_alive; then
+    log "Gateway restarted successfully (PID $(pgrep -f 'openclaw.*gateway' | head -1))"
+    return 0
+  else
+    log "Gateway failed to restart"
+    return 1
+  fi
+}
+
+escalate_to_kimi() {
+  log "Escalating to kimi -c for diagnosis (failure #$CONSECUTIVE_FAILURES)..."
+
+  local diag_file="/tmp/gateway-diag-$(date +%s).txt"
+  {
+    echo "=== OpenClaw Gateway Diagnostic Report ==="
+    echo "Timestamp: $(date -u)"
+    echo "Consecutive failures: $CONSECUTIVE_FAILURES"
+    echo ""
+    echo "=== Gateway Process ==="
+    ps aux | grep "[o]penclaw.*gateway" || echo "NO GATEWAY PROCESS RUNNING"
+    echo ""
+    echo "=== Port $GATEWAY_PORT ==="
+    ss -tlnp | grep "$GATEWAY_PORT" || echo "Port not listening"
+    echo ""
+    echo "=== Recent Gateway Logs (last 30 lines) ==="
+    tail -30 "/tmp/openclaw/openclaw-$(date -u +%Y-%m-%d).log" 2>/dev/null || echo "No log file"
+    echo ""
+    echo "=== Watcher Log (last 20 lines) ==="
+    tail -20 "$LOG" 2>/dev/null || echo "No watcher log"
+    echo ""
+    echo "=== Disk Usage ==="
+    df -h /home/openclaw
+    echo ""
+    echo "=== Memory ==="
+    free -h 2>/dev/null || echo "N/A"
+  } > "$diag_file" 2>&1
+
+  local fix_script="/tmp/gateway-fix-$(date +%s).sh"
+  kimi -c "You are the OpenClaw gateway doctor. Read the diagnostic report below and write a bash script to fix the issue. Rules: gateway command is openclaw gateway run --force --bind loopback --port 18790. HOME=/home/openclaw. NEVER use destructive commands. Output ONLY the bash script.
+
+$(cat "$diag_file")" > "$fix_script" 2>/dev/null
+
+  if [ -s "$fix_script" ]; then
+    log "Kimi produced fix script: $fix_script"
+
+    if grep -qiE "rm -rf /|mkfs|dd if=/dev|shutdown|reboot|halt|format" "$fix_script"; then
+      log "BLOCKED: Fix script contains dangerous commands, skipping"
+      rm -f "$fix_script" "$diag_file"
+      return 1
+    fi
+
+    chmod +x "$fix_script"
+    bash "$fix_script" >> "$LOG" 2>&1
+    local result=$?
+    log "Fix script exit code: $result"
+
+    sleep 5
+    if check_gateway_alive && check_gateway_responsive; then
+      log "Kimi fix successful — gateway is back up"
+    else
+      log "Kimi fix did not resolve the issue"
+    fi
+  else
+    log "Kimi produced no output or failed"
+  fi
+
+  rm -f "$fix_script" "$diag_file"
+}
+
+# === Main Loop ===
+log "Gateway watcher started (interval: ${CHECK_INTERVAL}s, kimi escalation after ${MAX_FAILURES_BEFORE_KIMI} failures)"
+
+while true; do
+  rotate_log
+
+  if ! check_gateway_alive; then
+    log "ALERT: Gateway process is dead!"
+    CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+
+    if [ $CONSECUTIVE_FAILURES -ge $MAX_FAILURES_BEFORE_KIMI ]; then
+      escalate_to_kimi
+      CONSECUTIVE_FAILURES=0
+    else
+      restart_gateway && CONSECUTIVE_FAILURES=0
+    fi
+    sleep $CHECK_INTERVAL
+    continue
+  fi
+
+  if ! check_gateway_responsive; then
+    log "ALERT: Gateway not responding on port $GATEWAY_PORT!"
+    CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+
+    if [ $CONSECUTIVE_FAILURES -ge $MAX_FAILURES_BEFORE_KIMI ]; then
+      escalate_to_kimi
+      CONSECUTIVE_FAILURES=0
+    else
+      restart_gateway && CONSECUTIVE_FAILURES=0
+    fi
+    sleep $CHECK_INTERVAL
+    continue
+  fi
+
+  if [ $CONSECUTIVE_FAILURES -gt 0 ]; then
+    log "Gateway recovered after $CONSECUTIVE_FAILURES failure(s)"
+  fi
+  CONSECUTIVE_FAILURES=0
+
+  sleep $CHECK_INTERVAL
+done

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# launch.sh — Main entrypoint for openclaw-launcher
+# Starts the gateway, watcher, and installs the hourly orchestrator cron
+#
+# Usage:
+#   ./launch.sh              # Start everything
+#   ./launch.sh --no-cron    # Start gateway only, skip cron install
+#   ./launch.sh --cron-only  # Only install the cron job (gateway must be running)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_DIR="${HOME}/logs"
+GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18790}"
+
+mkdir -p "$LOG_DIR"
+
+log() {
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "[$ts] [launcher] $1"
+}
+
+# ─── Load environment ─────────────────────────────────────────────────────────
+
+if [ -f "${HOME}/.env.keys" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${HOME}/.env.keys"
+  set +a
+fi
+
+export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+export HOME="${HOME:-/home/openclaw}"
+
+# Fix: OPENCLAW_HOME must not be set — CLI auto-resolves to ~/.openclaw
+unset OPENCLAW_HOME
+
+# ─── Parse args ───────────────────────────────────────────────────────────────
+
+SKIP_CRON=false
+CRON_ONLY=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-cron)    SKIP_CRON=true ;;
+    --cron-only)  CRON_ONLY=true ;;
+    --help|-h)
+      echo "Usage: $0 [--no-cron | --cron-only]"
+      echo ""
+      echo "Options:"
+      echo "  --no-cron     Start gateway and watcher, skip cron install"
+      echo "  --cron-only   Only install the orchestrator cron job"
+      echo ""
+      exit 0
+      ;;
+  esac
+done
+
+# ─── Cron-only mode ───────────────────────────────────────────────────────────
+
+if $CRON_ONLY; then
+  log "Installing orchestrator cron only..."
+  bash "${SCRIPT_DIR}/orchestrator/install-cron.sh"
+  exit $?
+fi
+
+# ─── Start Gateway ────────────────────────────────────────────────────────────
+
+start_gateway() {
+  # Check if already running
+  if timeout 3 bash -c "echo > /dev/tcp/127.0.0.1/$GATEWAY_PORT" 2>/dev/null; then
+    log "Gateway already running on port $GATEWAY_PORT"
+    return 0
+  fi
+
+  log "Starting gateway on port $GATEWAY_PORT..."
+
+  # Kill stale gateway processes
+  pkill -f "openclaw.*gateway" 2>/dev/null || true
+  sleep 2
+
+  nohup openclaw gateway run --force --bind loopback --port "$GATEWAY_PORT" \
+    >> "${LOG_DIR}/gateway.log" 2>&1 &
+
+  # Wait for gateway to be ready
+  local retries=0
+  while ! timeout 3 bash -c "echo > /dev/tcp/127.0.0.1/$GATEWAY_PORT" 2>/dev/null; do
+    retries=$((retries + 1))
+    if [ $retries -gt 15 ]; then
+      log "ERROR: Gateway failed to start after 30 seconds"
+      return 1
+    fi
+    sleep 2
+  done
+
+  log "Gateway started (PID $(pgrep -f 'openclaw.*gateway' | head -1))"
+}
+
+# ─── Start Gateway Watcher ────────────────────────────────────────────────────
+
+start_watcher() {
+  if pgrep -f "gateway-watcher.sh" >/dev/null 2>&1; then
+    log "Gateway watcher already running"
+    return 0
+  fi
+
+  if [ -f "${SCRIPT_DIR}/gateway-watcher.sh" ]; then
+    log "Starting gateway watcher..."
+    nohup bash "${SCRIPT_DIR}/gateway-watcher.sh" >> "${LOG_DIR}/gateway-watcher.log" 2>&1 &
+    log "Gateway watcher started"
+  else
+    log "WARNING: gateway-watcher.sh not found, skipping"
+  fi
+}
+
+# ─── Install Orchestrator Cron ─────────────────────────────────────────────────
+
+install_cron() {
+  if $SKIP_CRON; then
+    log "Skipping cron install (--no-cron)"
+    return 0
+  fi
+
+  log "Installing orchestrator cron..."
+
+  # Give the gateway a moment to fully initialize
+  sleep 3
+
+  bash "${SCRIPT_DIR}/orchestrator/install-cron.sh" 2>&1 || \
+    log "WARNING: Cron install failed (gateway may need more time, retry with: $0 --cron-only)"
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  echo ""
+  echo "╔══════════════════════════════════════════════╗"
+  echo "║       OpenClaw Launcher v1.1.0               ║"
+  echo "║  Gateway + Watcher + Orchestrator            ║"
+  echo "║  Brain: Kimi K2.5 | Executor: Claude Code   ║"
+  echo "╚══════════════════════════════════════════════╝"
+  echo ""
+
+  start_gateway
+  start_watcher
+  install_cron
+
+  echo ""
+  log "All services started."
+  log "  Gateway:      port $GATEWAY_PORT"
+  log "  Watcher:      running"
+  log "  Orchestrator: cron every 1h"
+  log ""
+  log "Logs: ${LOG_DIR}/"
+  log "Check cron: openclaw cron list"
+  log "Run now:    openclaw cron run orchestrator"
+  log "Manual run: bash ${SCRIPT_DIR}/orchestrator/orchestrator.sh"
+}
+
+main

--- a/orchestrator/install-cron.sh
+++ b/orchestrator/install-cron.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# install-cron.sh — Register the orchestrator as an hourly openclaw cron job
+# Requires the gateway to be running
+
+set -euo pipefail
+
+# Fix: OPENCLAW_HOME must not be set
+unset OPENCLAW_HOME
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ORCHESTRATOR_SCRIPT="${SCRIPT_DIR}/orchestrator.sh"
+GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18790}"
+
+echo "[install-cron] Installing orchestrator cron job..."
+
+# Check gateway is reachable
+if ! timeout 5 bash -c "echo > /dev/tcp/127.0.0.1/$GATEWAY_PORT" 2>/dev/null; then
+  echo "[install-cron] ERROR: Gateway not reachable on port $GATEWAY_PORT"
+  echo "[install-cron] Start the gateway first: openclaw gateway run --force --bind loopback --port $GATEWAY_PORT"
+  exit 1
+fi
+
+# Remove existing orchestrator cron if any
+existing=$(openclaw cron list --json 2>/dev/null | jq -r '.[] | select(.name == "orchestrator") | .id' 2>/dev/null || echo "")
+if [ -n "$existing" ]; then
+  echo "[install-cron] Removing existing orchestrator cron (id: $existing)..."
+  openclaw cron rm "$existing" 2>/dev/null || true
+fi
+
+# Register the hourly cron job
+openclaw cron add \
+  --name "orchestrator" \
+  --every 1h \
+  --description "Hourly orchestrator: PR review/merge, update checks, session maintenance" \
+  --system-event "Run the orchestrator cycle. Execute: bash ${ORCHESTRATOR_SCRIPT}. Tasks: 1) Session maintenance (openclaw sessions cleanup --all-agents --enforce) 2) Check GitHub repos for open PRs — review diffs using Claude Code AI, approve and merge good PRs, request changes on bad ones 3) Check for updates to openclaw (npm), claude-code (npm), kimi-code (npm), openclaw-launcher (git pull) 4) Use openclaw memory search for context when reviewing PRs 5) Log everything to ~/logs/orchestrator-*.log. Report a summary." \
+  --model "kimi-coding/k2p5" \
+  --session "main" \
+  --timeout 120000 \
+  2>/dev/null
+
+echo "[install-cron] Orchestrator cron job installed (runs every 1 hour)"
+echo "[install-cron] Model: kimi-coding/k2p5 (Kimi K2.5)"
+echo "[install-cron] To check status: openclaw cron list"
+echo "[install-cron] To run now: openclaw cron run orchestrator"

--- a/orchestrator/orchestrator.sh
+++ b/orchestrator/orchestrator.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+# orchestrator.sh — Hourly orchestrator launched via openclaw cron
+# Brain: Kimi K2.5 (kimi-coding/k2p5) driving Claude Code AIs
+#
+# Responsibilities:
+#   1. Review, test, approve, and merge GitHub PRs
+#   2. Check for updates: openclaw, claude code, kimi code, openclaw-launcher, ais
+#   3. Session maintenance via openclaw sessions cleanup
+#   4. Memory-aware decisions via openclaw memory search
+
+set -euo pipefail
+
+# Fix: OPENCLAW_HOME must not be set
+unset OPENCLAW_HOME
+export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_DIR="${HOME}/logs"
+LOG_FILE="${LOG_DIR}/orchestrator-$(date -u +%Y-%m-%d).log"
+LAUNCHER_REPO="${HOME}/openclaw-launcher"
+REPOS_TO_WATCH=(
+  "gastown-publish/openclaw-launcher"
+)
+
+mkdir -p "$LOG_DIR"
+
+log() {
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "[$ts] [orchestrator] $1" | tee -a "$LOG_FILE"
+}
+
+rotate_log() {
+  if [ -f "$LOG_FILE" ]; then
+    local size
+    size=$(stat -c%s "$LOG_FILE" 2>/dev/null || echo 0)
+    if [ "$size" -gt 5242880 ]; then
+      mv "$LOG_FILE" "$LOG_FILE.old"
+      log "Log rotated"
+    fi
+  fi
+}
+
+# ─── 1. PR Review, Test, Approve, Merge ───────────────────────────────────────
+
+review_and_merge_prs() {
+  log "=== PR Review Cycle ==="
+
+  for repo in "${REPOS_TO_WATCH[@]}"; do
+    log "Checking PRs for $repo..."
+
+    local prs
+    prs=$(gh pr list --repo "$repo" --state open --json number,title,headRefName,author --limit 20 2>/dev/null || echo "[]")
+
+    local count
+    count=$(echo "$prs" | jq 'length')
+
+    if [ "$count" -eq 0 ]; then
+      log "No open PRs for $repo"
+      continue
+    fi
+
+    log "Found $count open PR(s) for $repo"
+
+    echo "$prs" | jq -c '.[]' | while IFS= read -r pr; do
+      local pr_number pr_title pr_branch pr_author
+      pr_number=$(echo "$pr" | jq -r '.number')
+      pr_title=$(echo "$pr" | jq -r '.title')
+      pr_branch=$(echo "$pr" | jq -r '.headRefName')
+      pr_author=$(echo "$pr" | jq -r '.author.login')
+
+      log "Reviewing PR #${pr_number}: ${pr_title} (by ${pr_author})"
+
+      # Get the diff
+      local diff
+      diff=$(gh pr diff "$pr_number" --repo "$repo" 2>/dev/null || echo "")
+
+      if [ -z "$diff" ]; then
+        log "Could not fetch diff for PR #${pr_number}, skipping"
+        continue
+      fi
+
+      # Search memory for relevant context
+      local memory_context
+      memory_context=$(openclaw memory search --query "$pr_title" 2>/dev/null | head -20 || echo "No memory context")
+
+      # Drive Claude Code AI to review the PR
+      local review_prompt
+      review_prompt="You are a code reviewer for the openclaw-launcher project.
+
+Review this pull request and determine if it should be approved and merged.
+
+PR #${pr_number}: ${pr_title}
+Author: ${pr_author}
+Branch: ${pr_branch}
+
+Memory context from previous sessions:
+${memory_context}
+
+Diff:
+${diff}
+
+Instructions:
+1. Check for security issues, bugs, and code quality
+2. Verify the changes make sense given the project context
+3. Check if tests would pass (look for obvious breakage)
+4. Output EXACTLY one of these verdicts on the last line:
+   VERDICT: APPROVE
+   VERDICT: REQUEST_CHANGES
+   VERDICT: SKIP
+5. If REQUEST_CHANGES, explain what needs fixing before the verdict line"
+
+      local review_result
+      review_result=$(claude --dangerously-skip-permissions -p "$review_prompt" --output-format text 2>/dev/null || echo "VERDICT: SKIP")
+
+      local verdict
+      verdict=$(echo "$review_result" | grep "^VERDICT:" | tail -1 | awk '{print $2}')
+
+      case "$verdict" in
+        APPROVE)
+          log "PR #${pr_number} APPROVED by Claude Code AI"
+          gh pr review "$pr_number" --repo "$repo" --approve --body "Automated review by OpenClaw Orchestrator (Claude Code AI). Changes look good." 2>/dev/null || true
+          gh pr merge "$pr_number" --repo "$repo" --squash --auto 2>/dev/null || \
+            gh pr merge "$pr_number" --repo "$repo" --squash 2>/dev/null || \
+            log "Could not auto-merge PR #${pr_number} (may need manual merge)"
+          ;;
+        REQUEST_CHANGES)
+          local review_body
+          review_body=$(echo "$review_result" | grep -v "^VERDICT:" | tail -20)
+          log "PR #${pr_number} CHANGES REQUESTED"
+          gh pr review "$pr_number" --repo "$repo" --request-changes --body "Automated review by OpenClaw Orchestrator:
+
+${review_body}" 2>/dev/null || true
+          ;;
+        *)
+          log "PR #${pr_number} SKIPPED (verdict: ${verdict:-none})"
+          ;;
+      esac
+    done
+  done
+}
+
+# ─── 2. Update Checks ─────────────────────────────────────────────────────────
+
+check_updates() {
+  log "=== Update Check Cycle ==="
+
+  local updates_found=0
+
+  # OpenClaw
+  local current_openclaw installed_openclaw
+  current_openclaw=$(npm show openclaw version 2>/dev/null || echo "unknown")
+  installed_openclaw=$(openclaw --version 2>/dev/null | grep -oP '[\d.]+' | head -1 || echo "unknown")
+  if [ "$current_openclaw" != "$installed_openclaw" ] && [ "$current_openclaw" != "unknown" ]; then
+    log "UPDATE AVAILABLE: openclaw $installed_openclaw -> $current_openclaw"
+    npm install -g openclaw@latest 2>/dev/null && log "openclaw updated to $current_openclaw" || log "openclaw update failed"
+    updates_found=$((updates_found + 1))
+  else
+    log "openclaw is up to date ($installed_openclaw)"
+  fi
+
+  # Claude Code
+  local current_claude installed_claude
+  current_claude=$(npm show @anthropic-ai/claude-code version 2>/dev/null || echo "unknown")
+  installed_claude=$(claude --version 2>/dev/null | grep -oP '[\d.]+' | head -1 || echo "unknown")
+  if [ "$current_claude" != "$installed_claude" ] && [ "$current_claude" != "unknown" ]; then
+    log "UPDATE AVAILABLE: claude-code $installed_claude -> $current_claude"
+    npm install -g @anthropic-ai/claude-code@latest 2>/dev/null && log "claude-code updated to $current_claude" || log "claude-code update failed"
+    updates_found=$((updates_found + 1))
+  else
+    log "claude-code is up to date ($installed_claude)"
+  fi
+
+  # Kimi Code
+  local current_kimi installed_kimi
+  current_kimi=$(npm show kimi-code version 2>/dev/null || echo "unknown")
+  installed_kimi=$(kimi --version 2>/dev/null | grep -oP '[\d.]+' | head -1 || echo "unknown")
+  if [ "$current_kimi" != "$installed_kimi" ] && [ "$current_kimi" != "unknown" ]; then
+    log "UPDATE AVAILABLE: kimi-code $installed_kimi -> $current_kimi"
+    npm install -g kimi-code@latest 2>/dev/null && log "kimi-code updated to $current_kimi" || log "kimi-code update failed"
+    updates_found=$((updates_found + 1))
+  else
+    log "kimi-code is up to date ($installed_kimi)"
+  fi
+
+  # OpenClaw Launcher (git pull)
+  if [ -d "$LAUNCHER_REPO/.git" ]; then
+    local before_hash after_hash
+    before_hash=$(git -C "$LAUNCHER_REPO" rev-parse HEAD 2>/dev/null)
+    git -C "$LAUNCHER_REPO" pull --ff-only origin main 2>/dev/null || true
+    after_hash=$(git -C "$LAUNCHER_REPO" rev-parse HEAD 2>/dev/null)
+    if [ "$before_hash" != "$after_hash" ]; then
+      log "UPDATE: openclaw-launcher updated ($before_hash -> $after_hash)"
+      updates_found=$((updates_found + 1))
+    else
+      log "openclaw-launcher is up to date ($before_hash)"
+    fi
+  else
+    log "openclaw-launcher repo not found at $LAUNCHER_REPO"
+  fi
+
+  # AIs — check if claude/kimi binaries are functional
+  if claude --version >/dev/null 2>&1; then
+    log "Claude Code AI: operational"
+  else
+    log "WARNING: Claude Code AI not responding"
+  fi
+
+  if kimi --version >/dev/null 2>&1; then
+    log "Kimi Code AI: operational"
+  else
+    log "WARNING: Kimi Code AI not responding"
+  fi
+
+  log "Update check complete. $updates_found update(s) applied."
+}
+
+# ─── 3. Session Maintenance ───────────────────────────────────────────────────
+
+maintain_sessions() {
+  log "=== Session Maintenance ==="
+
+  openclaw sessions cleanup --all-agents --enforce 2>/dev/null && \
+    log "Session cleanup completed" || \
+    log "Session cleanup failed (gateway may be down)"
+
+  # Reindex memory after session cleanup
+  openclaw memory index 2>/dev/null && \
+    log "Memory reindexed" || \
+    log "Memory reindex failed"
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  log "========================================"
+  log "OpenClaw Orchestrator — Hourly Run"
+  log "Model: Kimi K2.5 (kimi-coding/k2p5)"
+  log "Executor: Claude Code AIs"
+  log "========================================"
+
+  rotate_log
+
+  # Phase 1: Session maintenance
+  maintain_sessions
+
+  # Phase 2: PR review and merge
+  review_and_merge_prs
+
+  # Phase 3: Update checks
+  check_updates
+
+  log "Orchestrator run complete."
+  log "========================================"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- **`orchestrator/orchestrator.sh`** — Hourly cron job driven by Kimi K2.5 (`kimi-coding/k2p5`) that dispatches to Claude Code AIs to review/merge PRs, check updates, and maintain sessions
- **`orchestrator/install-cron.sh`** — Registers the cron via `openclaw cron add --system-event`
- **`launch.sh`** — Single entrypoint: starts gateway + watcher + installs orchestrator cron
- **`gateway-watcher.sh`** — Self-healing gateway monitor with kimi escalation on repeated failures
- Fixes `OPENCLAW_HOME` env var bug that caused gateway config resolution failure
- Updates README with orchestrator architecture docs

## Test plan

- [x] Gateway starts and passes `openclaw health`
- [x] Cron job registered: `openclaw cron list` shows orchestrator every 1h
- [ ] Full launch: `./launch.sh`
- [ ] Orchestrator manual run: `bash orchestrator/orchestrator.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)